### PR TITLE
Fix WSL2 compatibility: Handle PermissionError in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ INSTALL_BIN_EXECUTABLES = ['redis-server', 'redis-cli']
 install_scripts = ''
 try:
     VERSION = check_output(['meta', 'get', 'package.version']).decode(errors='ignore')
-except (subprocess.CalledProcessError, FileNotFoundError):
+except (subprocess.CalledProcessError, FileNotFoundError, PermissionError):
     VERSION = REDIS_VERSION
 
 


### PR DESCRIPTION
WSL2's binfmt_misc interop causes subprocess to raise PermissionError instead of FileNotFoundError when executing non-existent commands. This fix adds PermissionError to the exception handler so the build can proceed with the fallback VERSION on WSL2 systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved robustness of the package setup process to handle edge cases more reliably and ensure graceful fallback behavior during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->